### PR TITLE
Added Lua5.4/LuaJIT support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,12 @@ RUN apt install -y golang-go
 
 # END install golang
 
+# install lua5.4, luajit
+RUN apt install -y luajit
+RUN apt install -y lua5.4
+
+# END install lua5.4, luajit
+
 COPY run-app.sh /run-app.sh
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ How this is going to work
 
 - A linux container
 - All the languages that I expect Hack Clubbers to use to develop their TerminalCraft projects in
-    - Ruby, Python, C/C++, Rust, JavaScript/Node.js, Java, C# (dotnet)
+    - Ruby, Python, C/C++, Rust, JavaScript/Node.js, Java, C# (dotnet), Lua 5.4, LuaJIT
 - The container is going to take as argument 
     - full url to project it has to clone from PR or folder in the terminalcraft repository
         - could even be just the branch name it has to checkout out to and commit hash/HEAD


### PR DESCRIPTION
I decided to edit the Dockerfile(and README) to hopefully add Lua support. I included Lua 5.4, since some people might want latest Lua, or if the project breaks with JIT. LuaJIT is there, because it can run stuff faster, and it also uses 5.1, which is pretty standard. 